### PR TITLE
Fix X11 controller crash/not working

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,14 @@ Fortunately, there are third-party mods available to address this issue.
 
 **WayGL:** [Modrinth](https://modrinth.com/mod/waygl), [Github](https://github.com/wired-tomato/WayGL)
 
+## 🛠️ Troubleshooting (Linux Fcitx5)
+
+Fcitx5 may not work without using the "On The Spot" style.
+
+1. Assuming your configuration program is `fcitx5-config-qt`, Head to `Fcitx Configuration -> Addons`, find `X Input Method Frontend` and click the cog button in its row.
+2. Enable the `Use On The Spot Style (Needs restarting)` option and restart Fcitx.
+3. It should be working now.
+
 ## 🚀️ Contributing
 All contributions are welcome regardless of Native or Java.
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Fortunately, there are third-party mods available to address this issue.
 Fcitx5 may not work without using the "On The Spot" style.
 
 1. Assuming your configuration program is `fcitx5-config-qt`, Head to `Fcitx Configuration -> Addons`, find `X Input Method Frontend` and click the cog button in its row.
-2. Enable the `Use On The Spot Style (Needs restarting)` option and restart Fcitx.
+2. Enable the `Use On The Spot Style (Needs restarting)` option then reboot.
 3. It should be working now.
 
 ## 🚀️ Contributing

--- a/common/src/main/java/moe/caramel/chat/driver/arch/x11/X11Controller.java
+++ b/common/src/main/java/moe/caramel/chat/driver/arch/x11/X11Controller.java
@@ -34,9 +34,9 @@ public final class X11Controller implements IController {
         }
 
         ModLogger.debug(
-                "[Native|Java] PreEdit: {} {} {} {} {} {} {} {}",
-                caret, chg_first, chg_length, length,
-                primary, secondary, tertiary, string
+            "[Native|Java] PreEdit: {} {} {} {} {} {} {} {}",
+            caret, chg_first, chg_length, length,
+            primary, secondary, tertiary, string
         );
 
         final int[] point = { 600, 600 };


### PR DESCRIPTION
Fixes #22, may fix #23 

Checked how CocoaInput handles X11Controller earlier, and looks like we need to make these callbacks as standalone fields to make sure they work and not crash the game.

IBus seems to work, Fcitx5 requires to enable "On The Spot" however, so this pr also includes a troubleshooting guide for these users.