### PR TITLE
Fix crash under Wayland when pressing Ctrl+A/C/X/V while previewing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,0 @@
-- Support Minecraft 1.21.6+
-- Temporary fix for sign crash issue (Fixes #34)

--- a/common/src/main/java/moe/caramel/chat/mixin/MixinEditBox.java
+++ b/common/src/main/java/moe/caramel/chat/mixin/MixinEditBox.java
@@ -1,10 +1,13 @@
 package moe.caramel.chat.mixin;
 
+import moe.caramel.chat.Main;
 import moe.caramel.chat.controller.EditBoxController;
+import moe.caramel.chat.driver.arch.wayland.WaylandController;
 import moe.caramel.chat.wrapper.AbstractIMEWrapper;
 import moe.caramel.chat.wrapper.WrapperEditBox;
 import net.minecraft.ChatFormatting;
 import net.minecraft.client.gui.components.EditBox;
+import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.network.chat.Style;
 import net.minecraft.util.FormattedCharSequence;
 import org.spongepowered.asm.mixin.Mixin;
@@ -14,6 +17,8 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.BiFunction;
@@ -205,6 +210,21 @@ public abstract class MixinEditBox implements EditBoxController {
     private void setCanLoseFocus(final boolean canLoseFocus, final CallbackInfo ci) {
         if (this.caramelChat$wrapper != null && !canLoseFocus) {
             this.caramelChat$wrapper.setFocused(true);
+        }
+    }
+
+    @Inject(method = "keyPressed", at = @At("HEAD"), cancellable = true)
+    private void keyPressed(int keyCode, int scanCode, int modifiers, CallbackInfoReturnable<Boolean> cir) {
+        if (!Main.getController().getClass().equals(WaylandController.class)) {
+            return;
+        }
+        if (caramelChat$wrapper.getStatus() == AbstractIMEWrapper.InputStatus.NONE) {
+            return;
+        }
+
+        if (Screen.isSelectAll(keyCode) || Screen.isCopy(keyCode) || Screen.isCut(keyCode) || Screen.isPaste(keyCode)) {
+            cir.setReturnValue(true);
+            cir.cancel();
         }
     }
 

--- a/common/src/main/java/moe/caramel/chat/mixin/MixinMultiLineEditBox.java
+++ b/common/src/main/java/moe/caramel/chat/mixin/MixinMultiLineEditBox.java
@@ -2,6 +2,8 @@ package moe.caramel.chat.mixin;
 
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import moe.caramel.chat.Main;
+import moe.caramel.chat.driver.arch.wayland.WaylandController;
 import moe.caramel.chat.wrapper.AbstractIMEWrapper;
 import moe.caramel.chat.wrapper.AbstractIMEWrapper.InputStatus;
 import moe.caramel.chat.wrapper.WrapperMultilineEditBox;
@@ -10,6 +12,7 @@ import net.minecraft.client.gui.Font;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.gui.components.MultiLineEditBox;
 import net.minecraft.client.gui.components.MultilineTextField;
+import net.minecraft.client.gui.screens.Screen;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -18,6 +21,7 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.ModifyArgs;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 import org.spongepowered.asm.mixin.injection.invoke.arg.Args;
 import java.util.function.Consumer;
 
@@ -137,6 +141,21 @@ public final class MixinMultiLineEditBox {
     private void setFocused(final boolean focused, final CallbackInfo ci) {
         if (this.caramelChat$wrapper != null) {
             this.caramelChat$wrapper.setFocused(focused);
+        }
+    }
+
+    @Inject(method = "keyPressed", at = @At("HEAD"), cancellable = true)
+    private void keyPressed(int keyCode, int scanCode, int modifiers, CallbackInfoReturnable<Boolean> cir) {
+        if (!Main.getController().getClass().equals(WaylandController.class)) {
+            return;
+        }
+        if (caramelChat$wrapper.getStatus() == AbstractIMEWrapper.InputStatus.NONE) {
+            return;
+        }
+
+        if (Screen.isSelectAll(keyCode) || Screen.isCopy(keyCode) || Screen.isCut(keyCode) || Screen.isPaste(keyCode)) {
+            cir.setReturnValue(true);
+            cir.cancel();
         }
     }
 

--- a/common/src/main/java/moe/caramel/chat/mixin/MixinSignEditScreen.java
+++ b/common/src/main/java/moe/caramel/chat/mixin/MixinSignEditScreen.java
@@ -2,13 +2,16 @@ package moe.caramel.chat.mixin;
 
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import moe.caramel.chat.Main;
 import moe.caramel.chat.controller.ScreenController;
+import moe.caramel.chat.driver.arch.wayland.WaylandController;
 import moe.caramel.chat.wrapper.AbstractIMEWrapper;
 import moe.caramel.chat.wrapper.WrapperSignEditScreen;
 import net.minecraft.ChatFormatting;
 import net.minecraft.client.gui.Font;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.gui.font.TextFieldHelper;
+import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.client.gui.screens.inventory.AbstractSignEditScreen;
 import org.jetbrains.annotations.Nullable;
 import org.spongepowered.asm.mixin.Mixin;
@@ -69,6 +72,12 @@ public final class MixinSignEditScreen implements ScreenController {
         )
     )
     private boolean helperKeyPressed(final TextFieldHelper helper, final int key) {
+        if (Main.getController().getClass().equals(WaylandController.class) && caramelChat$wrapper.getStatus() != AbstractIMEWrapper.InputStatus.NONE) {
+            if (Screen.isSelectAll(key) || Screen.isCopy(key) || Screen.isCut(key) || Screen.isPaste(key)) {
+                return true;
+            }
+        }
+
         final boolean result = helper.keyPressed(key);
         if (result) {
             this.caramelChat$wrapper.setToNoneStatus();

--- a/common/src/main/java/moe/caramel/chat/wrapper/AbstractIMEWrapper.java
+++ b/common/src/main/java/moe/caramel/chat/wrapper/AbstractIMEWrapper.java
@@ -127,7 +127,9 @@ public abstract class AbstractIMEWrapper {
         }
 
         ModLogger.debug("[Preview] Current: ({}) / Preview: ({})", this.origin, typing);
-        this.status = InputStatus.PREVIEW;
+        if (!typing.isEmpty()) {
+            this.status = InputStatus.PREVIEW;
+        }
 
         final int start = Math.min(this.getCursorPos(), this.getHighlightPos());
         final int end = Math.max(this.getCursorPos(), this.getHighlightPos());

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 org.gradle.jvmargs=-Xmx2G
 
 archives_base_name=caramelChat
-mod_version=1.2.2
+mod_version=1.2.3-SNAPSHOT
 maven_group=moe.caramel
 
 minecraft_version=1.21.6

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,7 +12,7 @@ neoforge_version=21.6.11-beta
 
 # Minotaur
 release_channel=release
-support_versions=1.21.6
+support_versions=1.21.6, 1.21.7
 
 # Other mods
 emi_version=1.1.12+1.21

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,7 +12,7 @@ neoforge_version=21.6.11-beta
 
 # Minotaur
 release_channel=release
-support_versions=1.21.6, 1.21.7
+support_versions=1.21.6, 1.21.7, 1.21.8
 
 # Other mods
 emi_version=1.1.12+1.21


### PR DESCRIPTION
Ctrl+ACXV pressed while previewing under Wayland is processed by Minecraft, which is not expected in previewing state and usually results a crash like: (mixins removed from stacktrace)

```java
java.lang.StringIndexOutOfBoundsException: Range [0, 3) out of bounds for length 0
	at java.base/jdk.internal.util.Preconditions$1.apply(Preconditions.java:55) ~[?:?] {}
	at java.base/jdk.internal.util.Preconditions$1.apply(Preconditions.java:52) ~[?:?] {}
	at java.base/jdk.internal.util.Preconditions$4.apply(Preconditions.java:213) ~[?:?] {}
	at java.base/jdk.internal.util.Preconditions$4.apply(Preconditions.java:210) ~[?:?] {}
	at java.base/jdk.internal.util.Preconditions.outOfBounds(Preconditions.java:98) ~[?:?] {}
	at java.base/jdk.internal.util.Preconditions.outOfBoundsCheckFromToIndex(Preconditions.java:112) ~[?:?] {}
	at java.base/jdk.internal.util.Preconditions.checkFromToIndex(Preconditions.java:349) ~[?:?] {}
	at java.base/java.lang.String.checkBoundsBeginEnd(String.java:4865) ~[?:?] 
	at java.base/java.lang.String.substring(String.java:2834) ~[?:?] 
	at TRANSFORMER/minecraft@1.21.1/net.minecraft.client.gui.components.EditBox.getHighlighted(EditBox.java:112) ~[client-1.21.1-20240808.144430-srg.jar%23318!/:?
	at TRANSFORMER/minecraft@1.21.1/net.minecraft.client.gui.components.EditBox.keyPressed(EditBox.java:280) ~[client-1.21.1-20240808.144430-srg.jar%23318!/:?]
	at TRANSFORMER/minecraft@1.21.1/net.minecraft.client.gui.components.events.ContainerEventHandler.keyPressed(ContainerEventHandler.java:80) ~[client-1.21.1-20240808.144430-srg.jar%23318!/:?]
	at TRANSFORMER/minecraft@1.21.1/net.minecraft.client.gui.screens.Screen.keyPressed(Screen.java:134) ~[client-1.21.1-20240808.144430-srg.jar%23318!/:?] 
	at TRANSFORMER/minecraft@1.21.1/net.minecraft.client.KeyboardHandler.lambda$keyPress$5(KeyboardHandler.java:411) ~[client-1.21.1-20240808.144430-srg.jar%23318!/:?] 
	at TRANSFORMER/minecraft@1.21.1/net.minecraft.client.gui.screens.Screen.wrapScreenError(Screen.java:451) ~[client-1.21.1-20240808.144430-srg.jar%23318!/:?] 
	at TRANSFORMER/minecraft@1.21.1/net.minecraft.client.KeyboardHandler.keyPress(KeyboardHandler.java:407) ~[client-1.21.1-20240808.144430-srg.jar%23318!/:?] 
	at TRANSFORMER/minecraft@1.21.1/net.minecraft.client.KeyboardHandler.lambda$setup$8(KeyboardHandler.java:515) ~[client-1.21.1-20240808.144430-srg.jar%23318!/:?] 
	at TRANSFORMER/minecraft@1.21.1/net.minecraft.util.thread.BlockableEventLoop.execute(BlockableEventLoop.java:98) ~[client-1.21.1-20240808.144430-srg.jar%23318!/:?] 
	at TRANSFORMER/minecraft@1.21.1/net.minecraft.client.KeyboardHandler.lambda$setup$9(KeyboardHandler.java:515) ~[client-1.21.1-20240808.144430-srg.jar%23318!/:?] 
	at MC-BOOTSTRAP/org.lwjgl.glfw@3.3.3+5/org.lwjgl.glfw.GLFWKeyCallbackI.callback(GLFWKeyCallbackI.java:44) ~[lwjgl-glfw-3.3.3.jar%2395!/:build 5] {}
	at MC-BOOTSTRAP/org.lwjgl@3.3.3+5/org.lwjgl.system.JNI.invokeV(Native Method) ~[lwjgl-3.3.3.jar%23107!/:build 5] {}
	at MC-BOOTSTRAP/org.lwjgl.glfw@3.3.3+5/org.lwjgl.glfw.GLFW.glfwWaitEventsTimeout(GLFW.java:3509) ~[lwjgl-glfw-3.3.3.jar%2395!/:build 5] 
	at TRANSFORMER/minecraft@1.21.1/com.mojang.blaze3d.systems.RenderSystem.limitDisplayFPS(RenderSystem.java:162) ~[client-1.21.1-20240808.144430-srg.jar%23318!/:?] 
	at TRANSFORMER/minecraft@1.21.1/net.minecraft.client.Minecraft.runTick(Minecraft.java:1220) ~[client-1.21.1-20240808.144430-srg.jar%23318!/:?] 
	at TRANSFORMER/minecraft@1.21.1/net.minecraft.client.Minecraft.run(Minecraft.java:807) ~[client-1.21.1-20240808.144430-srg.jar%23318!/:?] 
	at TRANSFORMER/minecraft@1.21.1/net.minecraft.client.main.Main.main(Main.java:230) ~[client-1.21.1-20240808.144430-srg.jar%23318!/:?] 
```

or

```java
com.sun.jna.Native$1 uncaughtException
java.lang.StringIndexOutOfBoundsException: Range [0, 3) out of bounds for length 0
<i lost the stacktrace owo>
```

This PR simply ignores the shortcuts when previewing under Wayland.