### PR TITLE
Add Ixeris compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,0 @@
-- Support Minecraft 1.21.9+

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -11,6 +11,7 @@ dependencies {
     // Other mods
     modCompileOnly "dev.emi:emi-xplat-intermediary:${emi_version}"
     modCompileOnly "maven.modrinth:xaeros-minimap:${xaeros_minimap_version}"
+    modCompileOnly "maven.modrinth:ixeris:${ixeris_version}"
 }
 
 architectury {

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -11,7 +11,7 @@ dependencies {
     // Other mods
     modCompileOnly "dev.emi:emi-xplat-intermediary:${emi_version}"
     modCompileOnly "maven.modrinth:xaeros-minimap:${xaeros_minimap_version}"
-    modCompileOnly "maven.modrinth:ixeris:${ixeris_version}"
+    compileOnly "maven.modrinth:ixeris:${ixeris_version}:api"
 }
 
 architectury {

--- a/common/src/main/java/moe/caramel/chat/Main.java
+++ b/common/src/main/java/moe/caramel/chat/Main.java
@@ -69,7 +69,7 @@ public final class Main {
      */
     public static void runOnMainThread(final Runnable runnable) {
         if (IXERIS_INSTALLED) {
-            IxerisApi.getInstance().runNowOnMainThread(runnable);
+            IxerisApi.getInstance().runOnMainThread(runnable);
         }
         else {
             runnable.run();

--- a/common/src/main/java/moe/caramel/chat/Main.java
+++ b/common/src/main/java/moe/caramel/chat/Main.java
@@ -2,16 +2,19 @@ package moe.caramel.chat;
 
 import com.sun.jna.Native;
 import com.sun.jna.Platform;
+import me.decce.ixeris.api.IxerisApi;
 import moe.caramel.chat.driver.IController;
 import moe.caramel.chat.driver.arch.unknown.UnknownController;
 import moe.caramel.chat.util.ModLogger;
 import net.minecraft.client.gui.screens.Screen;
+
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.lang.reflect.Method;
 import java.net.URL;
+import java.util.function.Supplier;
 
 /**
  * caramelChat Main
@@ -20,12 +23,13 @@ public final class Main {
 
     static { Main.instance = new Main(); }
     public static final boolean DEBUG = false;
+    public static final boolean IXERIS_INSTALLED = PlatformProvider.getProvider().isModLoaded("ixeris");
 
     private static Main instance;
     private final IController controller;
 
     private Main() {
-        this.controller = IController.getController();
+        this.controller = queryFromMainThread(IController::getController);
 
         if (controller instanceof UnknownController) {
             ModLogger.error("caramelChat can't find appropriate Controller in running OS");
@@ -56,7 +60,46 @@ public final class Main {
      * @param screen current screen
      */
     public static void setScreen(final Screen screen) {
-        Main.getController().changeFocusedScreen(screen);
+        runOnMainThread(() -> Main.getController().changeFocusedScreen(screen));
+    }
+
+    /**
+     * Runs the specified Runnable on the main thread
+     * @param runnable The Runnable to run on the main thread
+     */
+    public static void runOnMainThread(final Runnable runnable) {
+        if (IXERIS_INSTALLED) {
+            IxerisApi.getInstance().runNowOnMainThread(runnable);
+        }
+        else {
+            runnable.run();
+        }
+    }
+
+    /**
+     * Queries the result of the specified Supplier from the main thread
+     * @param supplier The Supplier to query from the main thread
+     */
+    public static <T> T queryFromMainThread(final Supplier<T> supplier) {
+        if (IXERIS_INSTALLED) {
+            return IxerisApi.getInstance().query(supplier);
+        }
+        else {
+            return supplier.get();
+        }
+    }
+
+    /**
+     * Runs the specified Runnable on the render thread
+     * @param runnable The Runnable to run on the render thread
+     */
+    public static void runOnRenderThread(final Runnable runnable) {
+        if (IXERIS_INSTALLED) {
+            IxerisApi.getInstance().runLaterOnRenderThread(runnable);
+        }
+        else {
+            runnable.run();
+        }
     }
 
     /**

--- a/common/src/main/java/moe/caramel/chat/PlatformProvider.java
+++ b/common/src/main/java/moe/caramel/chat/PlatformProvider.java
@@ -25,6 +25,11 @@ public abstract class PlatformProvider {
         public String getPlatformName() {
             return "UNKNOWN";
         }
+
+        @Override
+        public boolean isModLoaded(String modid) {
+            return false;
+        }
     };
 
     // ================================
@@ -69,6 +74,13 @@ public abstract class PlatformProvider {
      * @return platform name
      */
     public abstract String getPlatformName();
+
+    /**
+     * Checks if a specific mod is installed
+     *
+     * @return true if the specified mod is loaded
+     */
+    public abstract boolean isModLoaded(String modid);
 
     @Override
     public String toString() {

--- a/common/src/main/java/moe/caramel/chat/driver/arch/wayland/WaylandController.java
+++ b/common/src/main/java/moe/caramel/chat/driver/arch/wayland/WaylandController.java
@@ -32,26 +32,26 @@ public final class WaylandController implements IController {
             // Wayland Display Id
             GLFWNativeWayland.glfwGetWaylandDisplay(),
             // PreEdit
-            (str) -> {
+            (str) -> Main.runOnRenderThread(() -> {
                 if (focused != null) {
                     ModLogger.debug("[Native|Java] Preedit Callback (" + str.toString() + ")");
                     focused.getWrapper().appendPreviewText(str.toString());
                 }
-            },
+            }),
             // PreEdit (Null)
-            () -> {
+            () -> Main.runOnRenderThread(() -> {
                 if (focused != null) {
                     ModLogger.debug("[Native|Java] Preedit Null Callback");
                     focused.getWrapper().appendPreviewText("");
                 }
-            },
+            }),
             // Done
-            (str) -> {
+            (str) -> Main.runOnRenderThread(() -> {
                 if (focused != null) {
                     ModLogger.debug("[Native|Java] Done Callback (" + str.toString() + ")");
                     focused.getWrapper().insertText(str.toString());
                 }
-            },
+            }),
             // Rect
             (rect) -> {
                 if (focused != null) {

--- a/common/src/main/java/moe/caramel/chat/driver/arch/win/WinController.java
+++ b/common/src/main/java/moe/caramel/chat/driver/arch/win/WinController.java
@@ -33,19 +33,19 @@ public final class WinController implements IController {
             // Window Id
             GLFWNativeWin32.glfwGetWin32Window(Minecraft.getInstance().getWindow().handle()),
             // Pre Edit Callback
-            (str, cursor, length) -> {
+            (str, cursor, length) -> Main.runOnRenderThread(() -> {
                 if (focused != null) {
                     ModLogger.debug("[Native|Java] Preedit Callback (" + str.toString() + ") (" + cursor + ") (" + length + ")");
                     focused.getWrapper().appendPreviewText(str.toString());
                 }
-            },
+            }),
             // Done Callback
-            (str) -> {
+            (str) -> Main.runOnRenderThread(() -> {
                 if (focused != null) {
                     ModLogger.debug("[Native|Java] Done Callback (" + str.toString() + ")");
                     focused.getWrapper().insertText(str.toString());
                 }
-            },
+            }),
             // Rect Callback
             (rect) -> {
                 if (focused != null) {

--- a/common/src/main/java/moe/caramel/chat/driver/arch/x11/X11Controller.java
+++ b/common/src/main/java/moe/caramel/chat/driver/arch/x11/X11Controller.java
@@ -29,10 +29,12 @@ public final class X11Controller implements IController {
         ModLogger.debug("[Native|Java] Draw begin");
         final String string = (iswstring ? rawwstring.toString() : rawstring);
 
-        if (X11Controller.focused != null) {
-            GLFW.glfwSetKeyCallback(windowId, null);
-            X11Controller.focused.getWrapper().appendPreviewText(string);
-        }
+        Main.runOnRenderThread(() -> {
+            if (X11Controller.focused != null) {
+                GLFW.glfwSetKeyCallback(windowId, null);
+                X11Controller.focused.getWrapper().appendPreviewText(string);
+            }
+        });
 
         ModLogger.debug(
             "[Native|Java] PreEdit: {} {} {} {} {} {} {} {}",
@@ -48,13 +50,13 @@ public final class X11Controller implements IController {
     };
 
     @SuppressWarnings("FieldCanBeLocal")
-    private final Driver_X11.DoneCallback doneCallback = () -> {
+    private final Driver_X11.DoneCallback doneCallback = () -> Main.runOnRenderThread(() -> {
         ModLogger.debug("[Native|Java] Preedit Done");
         if (X11Controller.focused != null) {
             X11Controller.focused.getWrapper().insertText("");
         }
         X11Controller.setupKeyboardEvent();
-    };
+    });
 
     /**
      * Create X11 Controller

--- a/common/src/main/java/moe/caramel/chat/wrapper/AbstractIMEWrapper.java
+++ b/common/src/main/java/moe/caramel/chat/wrapper/AbstractIMEWrapper.java
@@ -20,7 +20,7 @@ public abstract class AbstractIMEWrapper {
     }
 
     protected AbstractIMEWrapper(final String defValue) {
-        this.ime = Main.getController().createOperator(this);
+        this.ime = Main.queryFromMainThread(() -> Main.getController().createOperator(this));
         this.origin = defValue;
     }
 
@@ -86,7 +86,7 @@ public abstract class AbstractIMEWrapper {
      * @param focused whether IME is enabled or not
      */
     public final void setFocused(final boolean focused) {
-        this.ime.setFocused(focused);
+        Main.runOnMainThread(() -> this.ime.setFocused(focused));
     }
 
     /**

--- a/fabric/src/main/java/moe/caramel/chat/fabric/FabricProvider.java
+++ b/fabric/src/main/java/moe/caramel/chat/fabric/FabricProvider.java
@@ -1,6 +1,7 @@
 package moe.caramel.chat.fabric;
 
 import moe.caramel.chat.PlatformProvider;
+import net.fabricmc.loader.api.FabricLoader;
 import net.fabricmc.loader.api.Version;
 
 /**
@@ -22,5 +23,10 @@ public final class FabricProvider extends PlatformProvider {
     @Override
     public String getPlatformName() {
         return "Fabric";
+    }
+
+    @Override
+    public boolean isModLoaded(String modid) {
+        return FabricLoader.getInstance().isModLoaded(modid);
     }
 }

--- a/forge/src/main/java/moe/caramel/chat/forge/ForgeProvider.java
+++ b/forge/src/main/java/moe/caramel/chat/forge/ForgeProvider.java
@@ -1,6 +1,7 @@
 package moe.caramel.chat.forge;
 
 import moe.caramel.chat.PlatformProvider;
+import net.minecraftforge.fml.ModList;
 
 /**
  * Forge Provider
@@ -21,5 +22,10 @@ public final class ForgeProvider extends PlatformProvider {
     @Override
     public String getPlatformName() {
         return "Forge";
+    }
+
+    @Override
+    public boolean isModLoaded(String modid) {
+        return ModList.get().isLoaded(modid);
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 org.gradle.jvmargs=-Xmx2G
 
 archives_base_name=caramelChat
-mod_version=1.2.2
+mod_version=1.2.3-SNAPSHOT
 maven_group=moe.caramel
 
 minecraft_version=1.21.9

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,4 +17,4 @@ support_versions=1.21.11
 # Other mods
 emi_version=1.1.12+1.21
 xaeros_minimap_version=fabric-1.21.11-25.3.10
-ixeris_version=4.1.8+1.21.11-fabric
+ixeris_version=3.8.6+1.21.11-fabric

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,3 +17,4 @@ support_versions=1.21.9, 1.21.10
 # Other mods
 emi_version=1.1.12+1.21
 xaeros_minimap_version=25.2.15_Fabric_1.21.9
+ixeris_version=3.6.3+1.21.10-fabric

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,4 +17,4 @@ support_versions=1.21.11
 # Other mods
 emi_version=1.1.12+1.21
 xaeros_minimap_version=fabric-1.21.11-25.3.10
-ixeris_version=3.8.6+1.21.11-fabric
+ixeris_version=4.4.0+1.21.11-fabric

--- a/neoforge/src/main/java/moe/caramel/chat/neoforge/NeoForgeProvider.java
+++ b/neoforge/src/main/java/moe/caramel/chat/neoforge/NeoForgeProvider.java
@@ -1,6 +1,7 @@
 package moe.caramel.chat.neoforge;
 
 import moe.caramel.chat.PlatformProvider;
+import net.neoforged.fml.ModList;
 
 /**
  * NeoForge Provider
@@ -21,5 +22,10 @@ public final class NeoForgeProvider extends PlatformProvider {
     @Override
     public String getPlatformName() {
         return "NeoForge";
+    }
+
+    @Override
+    public boolean isModLoaded(String modid) {
+        return ModList.get().isLoaded(modid);
     }
 }


### PR DESCRIPTION
This PR adds compatibility with Ixeris mod.

- Added method to `PlatformProvider` to check whether Ixeris is installed
- Added `Main#runOnMainThread`, `Main#queryFromMainThread` and `Main#runOnRenderThread`, which makes use of the API provided by Ixeris when it is installed

Closes #41 and https://github.com/decce6/Ixeris/issues/51