### PR TITLE
Fix macOS IME input in long-lived text fields

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -11,6 +11,13 @@ dependencies {
     // Other mods
     modCompileOnly "dev.emi:emi-xplat-intermediary:${emi_version}"
     modCompileOnly "maven.modrinth:xaeros-minimap:${xaeros_minimap_version}"
+
+    testImplementation platform("org.junit:junit-bom:5.10.3")
+    testImplementation "org.junit.jupiter:junit-jupiter"
+}
+
+tasks.withType(Test).configureEach {
+    useJUnitPlatform()
 }
 
 architectury {

--- a/common/src/main/java/moe/caramel/chat/driver/arch/darwin/DarwinController.java
+++ b/common/src/main/java/moe/caramel/chat/driver/arch/darwin/DarwinController.java
@@ -18,6 +18,7 @@ import java.util.Locale;
 public final class DarwinController implements IController {
 
     private final Driver_Darwin driver;
+    private long registryGeneration;
 
     /**
      * Create Darwin Controller
@@ -47,6 +48,7 @@ public final class DarwinController implements IController {
         }
 
         this.driver.refreshInstance();
+        this.registryGeneration++;
     }
 
     @Override
@@ -60,6 +62,15 @@ public final class DarwinController implements IController {
      */
     public Driver_Darwin getDriver() {
         return driver;
+    }
+
+    /**
+     * Gets the generation of the native text field registry.
+     *
+     * @return native registry generation
+     */
+    public long getRegistryGeneration() {
+        return registryGeneration;
     }
 
     @Override

--- a/common/src/main/java/moe/caramel/chat/driver/arch/darwin/DarwinFocusState.java
+++ b/common/src/main/java/moe/caramel/chat/driver/arch/darwin/DarwinFocusState.java
@@ -1,0 +1,37 @@
+package moe.caramel.chat.driver.arch.darwin;
+
+import java.util.function.IntConsumer;
+
+/**
+ * Tracks Java-side focus for a native CocoaInput text field.
+ */
+final class DarwinFocusState {
+
+    private boolean focused;
+    private long registeredGeneration;
+
+    public DarwinFocusState(final long registeredGeneration) {
+        this.registeredGeneration = registeredGeneration;
+    }
+
+    public void setFocused(
+        final boolean focus, final long registryGeneration,
+        final Runnable register, final IntConsumer setReceiver
+    ) {
+        final boolean registrationExpired = (this.registeredGeneration != registryGeneration);
+        if (focus && registrationExpired) {
+            register.run();
+            this.registeredGeneration = registryGeneration;
+        }
+
+        if (focus != this.focused || (focus && registrationExpired)) {
+            setReceiver.accept(focus ? 1 : 0);
+        }
+
+        this.focused = focus;
+    }
+
+    public boolean isFocused() {
+        return focused;
+    }
+}

--- a/common/src/main/java/moe/caramel/chat/driver/arch/darwin/DarwinOperator.java
+++ b/common/src/main/java/moe/caramel/chat/driver/arch/darwin/DarwinOperator.java
@@ -16,43 +16,50 @@ public class DarwinOperator implements IOperator {
     private final DarwinController controller;
     private final AbstractIMEWrapper wrapper;
     private final String uuid;
-    private boolean nowFocused;
+    private final DarwinFocusState focusState;
+    private final Driver_Darwin.InsertText insertText;
+    private final Driver_Darwin.SetMarkedText setMarkedText;
+    private final Driver_Darwin.FirstRectForCharacterRange firstRectForCharacterRange;
 
     public DarwinOperator(final DarwinController controller, final AbstractIMEWrapper wrapper) {
         this.controller = controller;
         this.wrapper = wrapper;
         this.uuid = UUID.randomUUID().toString();
+        this.focusState = new DarwinFocusState(controller.getRegistryGeneration());
+        this.insertText = (str, position, length) -> {
+            ModLogger.debug("[Native|Java] Textfield (" + uuid + ") received inserted text.");
+            this.wrapper.insertText(str);
+        };
+        this.setMarkedText = (str, position1, length1, position2, length2) -> {
+            ModLogger.debug("[Native|Java] MarkedText changed at (" + uuid + ").");
+            this.wrapper.appendPreviewText(str);
+        };
+        this.firstRectForCharacterRange = (pointer) -> {
+            ModLogger.debug("[Native|Java] Called to determine where to draw.");
+            final float[] buff = this.wrapper.getRect().copy();
+            final Window window = Minecraft.getInstance().getWindow();
+            final float factor = (float) window.getGuiScale();
+            buff[0] *= factor;
+            buff[1] *= factor;
+            buff[2] *= factor;
+            buff[3] *= factor;
 
+            buff[0] += window.getX();
+            buff[1] += window.getY();
+
+            pointer.write(0, buff, 0, 4);
+        };
+
+        this.registerInstance();
+    }
+
+    private void registerInstance() {
         ModLogger.debug("[Native|Java] IMEOperator addInstance: " + uuid);
         this.controller.getDriver().addInstance(
-            // UUID
             this.uuid,
-            // Insert Text
-            (str, position, length) -> {
-                ModLogger.debug("[Native|Java] Textfield (" + uuid + ") received inserted text.");
-                this.wrapper.insertText(str);
-            },
-            // Set Marked Text
-            (str, position1, length1, position2, length2) -> {
-                ModLogger.debug("[Native|Java] MarkedText changed at (" + uuid + ").");
-                this.wrapper.appendPreviewText(str);
-            },
-            // Rect Range
-            (pointer) -> {
-                ModLogger.debug("[Native|Java] Called to determine where to draw.");
-                final float[] buff = this.wrapper.getRect().copy();
-                final Window window = Minecraft.getInstance().getWindow();
-                final float factor = (float) window.getGuiScale();
-                buff[0] *= factor;
-                buff[1] *= factor;
-                buff[2] *= factor;
-                buff[3] *= factor;
-
-                buff[0] += window.getX();
-                buff[1] += window.getY();
-
-                pointer.write(0, buff, 0, 4);
-            }
+            this.insertText,
+            this.setMarkedText,
+            this.firstRectForCharacterRange
         );
     }
 
@@ -63,15 +70,14 @@ public class DarwinOperator implements IOperator {
 
     @Override
     public void setFocused(final boolean focus) {
-        if (focus != this.nowFocused) {
+        this.focusState.setFocused(focus, this.controller.getRegistryGeneration(), this::registerInstance, receive -> {
             ModLogger.debug("[Native|Java] IMEOperator.setFocused: " + focus);
-            this.controller.getDriver().setIfReceiveEvent(this.uuid, (focus ? 1 : 0));
-            this.nowFocused = focus;
-        }
+            this.controller.getDriver().setIfReceiveEvent(this.uuid, receive);
+        });
     }
 
     @Override
     public boolean isFocused() {
-        return nowFocused;
+        return this.focusState.isFocused();
     }
 }

--- a/common/src/main/java/moe/caramel/chat/mixin/MixinEditBox.java
+++ b/common/src/main/java/moe/caramel/chat/mixin/MixinEditBox.java
@@ -113,7 +113,7 @@ public abstract class MixinEditBox implements EditBoxController {
     @Inject(method = "setValue", at = @At("HEAD"))
     private void setValueHead(final String text, final CallbackInfo ci) {
         // setStatusToNone -> forceUpdateOrigin -> onValueChange
-        if (caramelChat$wrapper.valueChanged) {
+        if (caramelChat$wrapper.isInternalValueChange()) {
             this.caramelChat$cacheCursorPos = 0;
             this.caramelChat$cacheHighlightPos = 0;
         } else {
@@ -129,7 +129,7 @@ public abstract class MixinEditBox implements EditBoxController {
         )
     )
     private boolean setValuePredicateTest(final Predicate<String> predicate, final Object value) {
-        if (caramelChat$wrapper.valueChanged) {
+        if (caramelChat$wrapper.isInternalValueChange()) {
             this.caramelChat$cacheCursorPos = this.cursorPos;
             this.caramelChat$cacheHighlightPos = this.highlightPos;
             return true;
@@ -146,12 +146,11 @@ public abstract class MixinEditBox implements EditBoxController {
         ), cancellable = true
     )
     private void setValueInvoke(final String text, final CallbackInfo ci) {
-        if (caramelChat$wrapper.valueChanged) {
+        if (caramelChat$wrapper.isInternalValueChange()) {
             ci.cancel();
             // caxton Compatibility
             this.cursorPos = this.caramelChat$cacheCursorPos;
             this.highlightPos = this.caramelChat$cacheHighlightPos;
-            this.caramelChat$wrapper.valueChanged = false;
             return;
         }
 

--- a/common/src/main/java/moe/caramel/chat/wrapper/InternalValueChange.java
+++ b/common/src/main/java/moe/caramel/chat/wrapper/InternalValueChange.java
@@ -1,0 +1,22 @@
+package moe.caramel.chat.wrapper;
+
+/**
+ * Distinguishes IME preview updates from external value changes.
+ */
+final class InternalValueChange {
+
+    private boolean active;
+
+    public void run(final Runnable update) {
+        this.active = true;
+        try {
+            update.run();
+        } finally {
+            this.active = false;
+        }
+    }
+
+    public boolean isActive() {
+        return active;
+    }
+}

--- a/common/src/main/java/moe/caramel/chat/wrapper/WrapperEditBox.java
+++ b/common/src/main/java/moe/caramel/chat/wrapper/WrapperEditBox.java
@@ -10,7 +10,7 @@ public final class WrapperEditBox extends AbstractIMEWrapper {
 
     private final EditBox wrapped;
     private Runnable insertCallback;
-    public boolean valueChanged;
+    private final InternalValueChange valueChange = new InternalValueChange();
 
     public WrapperEditBox(final EditBox box) {
         super(box.value);
@@ -60,8 +60,7 @@ public final class WrapperEditBox extends AbstractIMEWrapper {
 
     @Override
     protected void setPreviewText(final String text) {
-        this.valueChanged = true;
-        this.wrapped.setValue(text);
+        this.valueChange.run(() -> this.wrapped.setValue(text));
 
         if (this.wrapped.isFocused()) {
             this.insertCallback.run();
@@ -83,5 +82,14 @@ public final class WrapperEditBox extends AbstractIMEWrapper {
      */
     public void setInsertCallback(final Runnable callback) {
         this.insertCallback = callback;
+    }
+
+    /**
+     * Gets whether the value is being updated internally for an IME preview.
+     *
+     * @return whether an internal value update is in progress
+     */
+    public boolean isInternalValueChange() {
+        return this.valueChange.isActive();
     }
 }

--- a/common/src/test/java/moe/caramel/chat/driver/arch/darwin/DarwinFocusStateTest.java
+++ b/common/src/test/java/moe/caramel/chat/driver/arch/darwin/DarwinFocusStateTest.java
@@ -1,0 +1,48 @@
+package moe.caramel.chat.driver.arch.darwin;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+
+final class DarwinFocusStateTest {
+
+    @Test
+    void reRegistersAndReactivatesAfterNativeRegistryRefresh() {
+        final DarwinFocusState state = new DarwinFocusState(0);
+        final AtomicInteger registrations = new AtomicInteger();
+        final List<Integer> receiverChanges = new ArrayList<>();
+
+        state.setFocused(true, 0, registrations::incrementAndGet, receiverChanges::add);
+
+        // Native refreshInstance() forgets every registration, but Java-side focus can remain true.
+        state.setFocused(true, 1, registrations::incrementAndGet, receiverChanges::add);
+
+        assertEquals(1, registrations.get());
+        assertEquals(List.of(1, 1), receiverChanges);
+        assertTrue(state.isFocused());
+
+        state.setFocused(false, 1, registrations::incrementAndGet, receiverChanges::add);
+        state.setFocused(false, 1, registrations::incrementAndGet, receiverChanges::add);
+
+        assertEquals(1, registrations.get());
+        assertEquals(List.of(1, 1, 0), receiverChanges);
+        assertFalse(state.isFocused());
+    }
+
+    @Test
+    void doesNotReRegisterWhileNativeRegistryIsUnchanged() {
+        final DarwinFocusState state = new DarwinFocusState(0);
+        final AtomicInteger registrations = new AtomicInteger();
+        final List<Integer> receiverChanges = new ArrayList<>();
+
+        state.setFocused(true, 0, registrations::incrementAndGet, receiverChanges::add);
+        state.setFocused(true, 0, registrations::incrementAndGet, receiverChanges::add);
+
+        assertEquals(0, registrations.get());
+        assertEquals(List.of(1), receiverChanges);
+    }
+}

--- a/common/src/test/java/moe/caramel/chat/wrapper/InternalValueChangeTest.java
+++ b/common/src/test/java/moe/caramel/chat/wrapper/InternalValueChangeTest.java
@@ -1,0 +1,29 @@
+package moe.caramel.chat.wrapper;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
+
+final class InternalValueChangeTest {
+
+    @Test
+    void clearsFlagWhenWidgetSkipsAnUnchangedValueUpdate() {
+        final InternalValueChange change = new InternalValueChange();
+
+        change.run(() -> assertTrue(change.isActive()));
+
+        assertFalse(change.isActive());
+    }
+
+    @Test
+    void clearsFlagWhenWidgetUpdateThrows() {
+        final InternalValueChange change = new InternalValueChange();
+
+        assertThrows(IllegalStateException.class, () -> change.run(() -> {
+            throw new IllegalStateException("widget update failed");
+        }));
+
+        assertFalse(change.isActive());
+    }
+}


### PR DESCRIPTION
This fixes IME input for text fields that outlive the current screen, including EMI and JEI search fields on Minecraft 1.20.1.

- Re-registers Darwin input callbacks after the native text field registry is refreshed.
- Always clears the internal preview-update state when a widget skips an unchanged `setValue` call. This prevents cleared JEI search text from returning and avoids an invalid `EditBox` render state.

Tested on macOS with Forge 1.20.1:

- EMI 1.1.24: ASCII input, Japanese conversion and commit, and clearing
- JEI 15.48.0.180: the same input cases and repeated right-click clearing
- `./gradlew cleanTest test build --no-daemon`